### PR TITLE
fix: final solution for source_date issue

### DIFF
--- a/src/components/PromiseEditor.vue
+++ b/src/components/PromiseEditor.vue
@@ -146,7 +146,7 @@
 
           <el-col :xs="24" :sm="12" >
               <el-form-item label="Source Date" prop="source_date">
-            <el-date-picker type="date" placeholder="enter source date" v-model="promise.source_date"></el-date-picker>
+            <el-date-picker type="date" value-format="yyyy-MM-dd" placeholder="enter source date" v-model="promise.source_date"></el-date-picker>
               </el-form-item>
           </el-col>
 


### PR DESCRIPTION
http://element.eleme.io/#/en-US/component/date-picker#date-formats

Description:
* DatePicker was assigning a Date object whereas we expect it to be a string
* on API, it's string
* in this component, validation requires it to be a string
* problem is absent when editing existing promise
* problem is present when creating new promise and selecting source_date for the first time